### PR TITLE
Rip out doctest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ clean:
 .PHONY: dependencies
 dependencies:
 	stack update
-	cd && stack install doctest
 
 .PHONY: build
 build:
@@ -16,5 +15,4 @@ build:
 
 .PHONY: tests
 tests:
-	doctest src
 	stack test

--- a/src/Math/Combinatorics.hs
+++ b/src/Math/Combinatorics.hs
@@ -12,7 +12,5 @@ binaryRecurrence f x y = x : y : zipWith f (tail self) self
   where self = binaryRecurrence f x y
 
 -- | The infinite sequence of Fibonacci numbers.
--- >>> take 7 fibonacci
--- [0,1,1,2,3,5,8]
 fibonacci :: Num a => [a]
 fibonacci = binaryRecurrence (+) 0 1

--- a/test/Tests/Math/Combinatorics.hs
+++ b/test/Tests/Math/Combinatorics.hs
@@ -12,4 +12,9 @@ testBinaryRecurrence = TestList $ map TestCase
     assertEqual "Applies the function in the correct order" [0, 1, -1, 2, -3, 5, -8, 13] (take 8 $ binaryRecurrence subtract 0 1)
   ]
 
-tests = TestList [testBinaryRecurrence]
+testFibonacci = TestList $ map TestCase
+  [
+    assertEqual "First 7 Fibonacci numbers" [0, 1, 1, 2, 3, 5, 8] (take 7 fibonacci)
+  ]
+
+tests = TestList [testBinaryRecurrence, testFibonacci]


### PR DESCRIPTION
I like doctest in Python, but here it's just an extra dependency that adds complexity to the build.  For a library with public docs it would be great, but for goofing off here I'll just take the unit tests.