### PR TITLE
Add tests for the Core module

### DIFF
--- a/Project-Euler-Haskell.cabal
+++ b/Project-Euler-Haskell.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 8d5049cef429916d9a86f30b94568bdeabf18f5033cea26682878534ac3d29de
+-- hash: 48b016f71c47fd5fbb000ed017004133a1f2dd64962327de4a1afab279e0aaa6
 
 name:           Project-Euler-Haskell
 version:        1.0.0.0
@@ -59,6 +59,7 @@ test-suite Project-Euler-Haskell-Tests
   type: exitcode-stdio-1.0
   main-is: TestMain.hs
   other-modules:
+      Tests.Core
       Tests.Data.Grid
       Tests.Math
       Tests.Math.Combinatorics

--- a/src/Core.hs
+++ b/src/Core.hs
@@ -25,4 +25,6 @@ range a b = [a .. b]
 
 -- | The sublist of a list from positions `i` to `j`, inclusive.
 slice :: Int -> Int -> [a] -> [a]
-slice i j = take (j - i + 1) . drop i
+slice i j
+  | i < 0     = slice 0 j
+  | otherwise = take (j - i + 1) . drop i

--- a/test/Tests/Core.hs
+++ b/test/Tests/Core.hs
@@ -1,0 +1,31 @@
+module Tests.Core where
+
+import Core
+import Test.Tasty
+import Test.Tasty.HUnit
+
+test_consecutives = testGroup "consecutives"
+  [
+    testCase "0"          $ consecutives 0 [1 .. 4] @?= [],
+    testCase "1"          $ consecutives 1 [1 .. 4] @?= [[1], [2], [3], [4]],
+    testCase "2"          $ consecutives 2 [1 .. 4] @?= [[1, 2], [2, 3], [3, 4]],
+    testCase "Empty list" $ consecutives 3 []       @?= ([] :: [[Int]])
+  ]
+
+test_indices = testGroup "indices"
+  [
+    testCase "Empty list"    $ indices []        @?= [],
+    testCase "Nonempty list" $ indices [4, 5, 6] @?= [0, 1, 2]
+  ]
+
+test_slice = testGroup "slice"
+  [
+    testCase "Empty list"          $ slice 0 100 []         @?= ([] :: [Int]),
+    testCase "Start out of bounds" $ slice (-1) 1 [0, 1, 2] @?= [0, 1],
+    testCase "End out of bounds"   $ slice 1 10 [0, 1, 2]   @?= [1, 2],
+    testCase "Slice beginning"     $ slice 0 2 [1 .. 5]     @?= [1, 2, 3],
+    testCase "Slice middle"        $ slice 2 3 [1 .. 5]     @?= [3, 4],
+    testCase "Slice end"           $ slice 3 4 [1 .. 5]     @?= [4, 5],
+    testCase "Singleton slice"     $ slice 2 2 [1 .. 5]     @?= [3],
+    testCase "Empty slice"         $ slice 4 3 [1 .. 5]     @?= []
+  ]

--- a/test/Tests/Core.hs
+++ b/test/Tests/Core.hs
@@ -21,12 +21,13 @@ test_indices = testGroup "indices"
 
 test_slice = testGroup "slice"
   [
-    testCase "Empty list"          $ slice 0 100 []         @?= ([] :: [Void]),
-    testCase "Start out of bounds" $ slice (-1) 1 [0, 1, 2] @?= [0, 1],
-    testCase "End out of bounds"   $ slice 1 10 [0, 1, 2]   @?= [1, 2],
-    testCase "Slice beginning"     $ slice 0 2 [1 .. 5]     @?= [1, 2, 3],
-    testCase "Slice middle"        $ slice 2 3 [1 .. 5]     @?= [3, 4],
-    testCase "Slice end"           $ slice 3 4 [1 .. 5]     @?= [4, 5],
-    testCase "Singleton slice"     $ slice 2 2 [1 .. 5]     @?= [3],
-    testCase "Empty slice"         $ slice 4 3 [1 .. 5]     @?= []
+    testCase "Empty list"          $ slice 0 100 []            @?= ([] :: [Void]),
+    testCase "Start out of bounds" $ slice (-1) 1 [0, 1, 2]    @?= [0, 1],
+    testCase "End out of bounds"   $ slice 1 10 [0, 1, 2]      @?= [1, 2],
+    testCase "Start, end negative" $ slice (-4) (-1) [0, 1, 2] @?= [],
+    testCase "Slice beginning"     $ slice 0 2 [1 .. 5]        @?= [1, 2, 3],
+    testCase "Slice middle"        $ slice 2 3 [1 .. 5]        @?= [3, 4],
+    testCase "Slice end"           $ slice 3 4 [1 .. 5]        @?= [4, 5],
+    testCase "Singleton slice"     $ slice 2 2 [1 .. 5]        @?= [3],
+    testCase "Empty slice"         $ slice 4 3 [1 .. 5]        @?= []
   ]

--- a/test/Tests/Core.hs
+++ b/test/Tests/Core.hs
@@ -1,6 +1,7 @@
 module Tests.Core where
 
 import Core
+import Data.Void
 import Test.Tasty
 import Test.Tasty.HUnit
 
@@ -9,7 +10,7 @@ test_consecutives = testGroup "consecutives"
     testCase "0"          $ consecutives 0 [1 .. 4] @?= [],
     testCase "1"          $ consecutives 1 [1 .. 4] @?= [[1], [2], [3], [4]],
     testCase "2"          $ consecutives 2 [1 .. 4] @?= [[1, 2], [2, 3], [3, 4]],
-    testCase "Empty list" $ consecutives 3 []       @?= ([] :: [[Int]])
+    testCase "Empty list" $ consecutives 3 []       @?= ([] :: [[Void]])
   ]
 
 test_indices = testGroup "indices"
@@ -20,7 +21,7 @@ test_indices = testGroup "indices"
 
 test_slice = testGroup "slice"
   [
-    testCase "Empty list"          $ slice 0 100 []         @?= ([] :: [Int]),
+    testCase "Empty list"          $ slice 0 100 []         @?= ([] :: [Void]),
     testCase "Start out of bounds" $ slice (-1) 1 [0, 1, 2] @?= [0, 1],
     testCase "End out of bounds"   $ slice 1 10 [0, 1, 2]   @?= [1, 2],
     testCase "Slice beginning"     $ slice 0 2 [1 .. 5]     @?= [1, 2, 3],


### PR DESCRIPTION
Fix a bug in `slice`, which could produce incorrect results for negative inputs.